### PR TITLE
Fix en passant when attacking on left side of pawn

### DIFF
--- a/scripts/Analyzer.js
+++ b/scripts/Analyzer.js
@@ -203,7 +203,7 @@ CHESSAPP.Analyzer ={
 						enx : curx - 1,
 						eny : cury
 					};
-					mk(curx+1, cury - 1 * flip, true, true, special);
+					mk(curx - 1, cury + 1 * flip, true, true, special);
 				}
 
 				//check if pieces in either attack location


### PR DESCRIPTION
I noticed that en passant only works for white pawns attacking right and black pawns attacking left. An opposing pawn moving two steps on the other sides would still trigger the possibility to take a piece, but the attacking pawn would go one step diagonally backwards instead of forwards in that case. This change should fix it :)

Steps to reproduce: e4, a6; e5, d5. Then click the white pawn on e5; the red square will show up on f4 instead of d6.